### PR TITLE
Exit 1 on unhandled promise rejection

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,3 +1,8 @@
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('Unhandled Rejection at:', promise, 'reason:', reason);
+  process.exit(1);
+});
+
 var RDBtoBigQuery = require('./lib/RDBtoBigQuery');
 
 let sqlToBq = new RDBtoBigQuery();

--- a/app/index.js
+++ b/app/index.js
@@ -14,6 +14,9 @@ tablesToSend.forEach((table) => {
   if (tableProperties.length === 2 && (tableProperties[1] === 'append' || tableProperties[1] === 'snapshot')) {
     result = result.then(() => {
       return sqlToBq.exec(tableProperties[0],tableProperties[1]);    
+    }).catch(function (error) {
+      console.error(table, 'Error occured sending tables:', error);
+      process.exit(1);
     });
   } else {
     console.error('table option not formatted correct, use comma separated list of `tablename:append` or `tablename:snapshot`, got: ' + table);


### PR DESCRIPTION
On unhandled promises, nodejs by default gives a warning. However, experience has shown that this causes the script to hang (i.e. never exits). 

Rewriting the code to properly handle these problems, seems too risky. Additionally, in time I want to deprecate this script with something that has tests.. 